### PR TITLE
Add resource adapter profile to insertnode_request for scalesets

### DIFF
--- a/src/tortuga/resourceAdapter/gceadapter/gce.py
+++ b/src/tortuga/resourceAdapter/gceadapter/gce.py
@@ -1521,8 +1521,9 @@ insertnode_request = None
         config = session['config']
 
         insertnode_request = {
-                   'softwareProfile': softwareProfile,
-                   'hardwareProfile': hardwareProfile,
+            'softwareProfile': softwareProfile,
+            'hardwareProfile': hardwareProfile,
+            'resource_adapter_configuration': resourceAdapterProfile,
         }
 
         try:


### PR DESCRIPTION
Add the name of the resource adapter profile to the `insertnode_request` so that when a node is created in a scaleset and it pings the tortuga REST API, it will provide its resource adapter profile name so that tortuga can load the proper configuration.

At present, it doesn't find any information about the resource adapter profile, so it just uses the `Default` profile.

I tested this in a live Launch demo.  I put a logging statement in the `start()` method of the resource adapter to dump out the `addNodesRequest` and got

```
{
    'softwareProfile': '8f8e34fa-9abb-498a-9ab7-c789ad105600',
    'hardwareProfile': '8f8e34fa-9abb-498a-9ab7-c789ad105600',
    'resource_adapter_configuration': '559172db-0e4e-4672-a324-77a24b157745',
    'count': 1,
    'nodeDetails': [
        {
            'name': 'scale-set-aa0e2c26-97d4-409b-a84a-a00fd4d35747-dtgm.c.univa-tprestegard.internal',
            'metadata': {'instance_name': 'scale-set-aa0e2c26-97d4-409b-a84a-a00fd4d35747-dtgm'}
        }
    ],
    'addHostSession': '38ec7933-b105-4dcd-af92-0932bede1f22'
}
```