### PR TITLE
Ensure only 1 CentOS 7 image from official project is found during setup

### DIFF
--- a/src/tortuga/scripts/setup_gce.py
+++ b/src/tortuga/scripts/setup_gce.py
@@ -277,8 +277,8 @@ class ResourceAdapterSetup(TortugaCli):
         return network
 
     def _get_image_url(self):
-        cmd = ['compute', 'images', 'list', '--filter=name~"centos-7.*"',
-               '--uri']
+        cmd = ['compute', 'images', 'list', '--project=centos-cloud',
+               '--filter=family:centos-7', '--uri']
         url = self._run_gcloud(cmd)
         print(self.format('Image: {}', url))
 


### PR DESCRIPTION
During the default setup procedure, this command is run to find the latest CentOS 7 image:
```
gcloud compute images list --filter=name~"centos-7.*" --uri   
```
This finds any image under "standard" projects as well as one's own that have "centos-7" somewhere in them (there is no implied `^` in the regex at the beginning). This PR replaces that command with:
```
gcloud compute images list --project=centos-cloud --filter=family:centos-7 --uri
```
Which, by the behavior of the client and image maintenance, safely returns the latest official image.