### PR TITLE
Start to standardize startup scripts across adapter kits

### DIFF
--- a/src/tortuga/resourceAdapter/gceadapter/gce.py
+++ b/src/tortuga/resourceAdapter/gceadapter/gce.py
@@ -550,13 +550,20 @@ class Gce(ResourceAdapter): \
             'connection': gceAuthorize_from_json(config.get('json_keyfile')),
         }
 
-    def __getStartupScript(self, configDict: dict, insertnode_request: Optional[bytes] = None) -> Optional[str]:
+    def generate_startup_script(self, configDict: dict,
+                                insertnode_request: Optional[bytes] = None) \
+            -> Optional[str]:
         """
         Build a node/instance-specific startup script that will initialize
-        VPN, install Puppet, and the bootstrap the instance.
-        """
+        VPN, install Puppet, and bootstrap the instance.
 
-        self._logger.debug('__getStartupScript()')
+        :param configDict: resource adapter configuration settings
+        :param insertnode_request: encrypted insertnode_request, optional
+
+        :return: full startup script as a `str`, or `None` if template
+                 not found
+        """
+        self._logger.debug('generate_startup_script()')
 
         if not os.path.exists(configDict['startup_script_template']):
             self._logger.warning(
@@ -752,7 +759,10 @@ insertnode_request = None
 
         # Default to using startup-script
         if 'startup_script_template' in session['config']:
-            startup_script = self.__getStartupScript(session['config'], insertnode_request)
+            startup_script = self.generate_startup_script(
+                session['config'],
+                insertnode_request=insertnode_request
+            )
 
             if startup_script:
                 metadata.append(('startup-script', startup_script))

--- a/tortuga_kits/gceadapter/files/startup_script.py
+++ b/tortuga_kits/gceadapter/files/startup_script.py
@@ -67,7 +67,9 @@ def addNode():
                 }
             }
            }
-    print(data)
+    # Add nodes workflow must print insertnode_request as JSON with specified
+    # prefix so other tools can read this information
+    print('Instance details: ' + json.dumps(data))
     url = 'https://%s:%s/v1/node-token/%s' % (installerHostName, port, insertnode_request)
     req = urllib2.Request(url)
 


### PR DESCRIPTION
Standardize method name and args for generating the startup/bootstrap script.  I've basically just renamed `__getStartupScript` to `generate_startup_script` and will plan to use that method name across all other adapter kits going forward.  I thought about keeping the old method and just using it to call the new one for backwards compatibility, but I couldn't find anywhere else that used `__getStartupScript` directly, so I thought I'd minimize the clutter and just get rid of it.

I also added a statement in the bootstrap script template which will print out the instance configuration details as a JSON so that other tools can parse it.  Planning to add this to templates in other adapter kits, as well.
