### PR TITLE
Update scaleset management

### DIFF
--- a/kit.json
+++ b/kit.json
@@ -3,5 +3,5 @@
   "version": "7.1.0",
   "iteration": "0",
   "description": "Google Compute Engine resource adapter",
-  "requires_core": "7.1.0+005"
+  "requires_core": "7.1.0+006"
 }

--- a/src/tortuga/resourceAdapter/gceadapter/gce.py
+++ b/src/tortuga/resourceAdapter/gceadapter/gce.py
@@ -1428,8 +1428,8 @@ insertnode_request = None
 
     def delete_scale_set(self,
               name: str,
-              resourceAdapterProfile: str):
-
+              resourceAdapterProfile: str,
+              adapter_args: dict={}):
         """
         Delete an existing scale set
 
@@ -1438,12 +1438,9 @@ insertnode_request = None
         session = self.get_gce_session(
             resourceAdapterProfile
         )
-
         connection = session['connection']
-
         config = session['config']
-
-        normalized_name = "scale-set-" + name
+        normalized_name = f"scale-set-{name}"
 
         try:
             initial_response = connection.svc.instanceGroupManagers().delete(
@@ -1462,6 +1459,9 @@ insertnode_request = None
                 raise
         finally:
             try:
+                # If the instance template was created specifically for this
+                # scale set (i.e., its name is 'scale-set-{instancegroupname}')
+                # then delete it
                 connection.svc.instanceTemplates().delete(
                     project=config['project'],
                     instanceTemplate=normalized_name
@@ -1474,12 +1474,8 @@ insertnode_request = None
     def update_scale_set(self,
               name: str,
               resourceAdapterProfile: str,
-              hardwareProfile: str,
-              softwareProfile: str,
-              minCount: int,
-              maxCount: int,
               desiredCount: int,
-              adapter_args: dict):
+              adapter_args: dict={}):
 
         """
         Updates an existing scale set
@@ -1487,20 +1483,13 @@ insertnode_request = None
         :raises InvalidArgument:
 
         """
-        adapter_config = self.get_config(resourceAdapterProfile)
-        tags = self.get_initial_tags(adapter_config, hardwareProfile,
-                                     softwareProfile)
-
+        normalized_name = f'scale-set-{name}'
         session = self.get_gce_session(
             resourceAdapterProfile
         )
-        session['tags'] = tags
-
         connection = session['connection']
-
         config = session['config']
 
-        normalized_name = "scale-set-" + name
         connection.svc.instanceGroupManagers().resize(
             project=config['project'],
             zone=config['zone'],
@@ -1603,27 +1592,30 @@ insertnode_request = None
     def create_scale_set(self,
               name: str,
               resourceAdapterProfile: str,
-              hardwareProfile: str,
-              softwareProfile: str,
-              minCount: int,
-              maxCount: int,
               desiredCount: int,
-              adapter_args: dict,
-              instance_template_name: str=None):
+              hardwareProfile: str=None,
+              softwareProfile: str=None,
+              instance_template_name: str=None,
+              adapter_args: dict={}):
         """
         Create a scale set in GCE
 
-        If instance_template is not provided, we create an instance template
-        specifically for this scale set.
+        If instance_template_name is not provided, we create an instance
+        template specifically for this scale set.
 
         :raises InvalidArgument:
         """
         self._logger.debug(
             'create_scale_set(): name=[%s]', name)
 
+        # Add the 'scale-set-' prefix to the name - this is kind of an
+        # implicit indicator that the scale set is managed by Tortuga
+        name = f'scale-set-{name}'
+
         # Set up GCE session
         session = self.get_gce_session(resourceAdapterProfile)
         config = session['config']
+        connection = session['connection']
 
         # If no instance template is provided, create one specifically for this
         # scale set.
@@ -1632,8 +1624,6 @@ insertnode_request = None
             # TODO: confirm that provided instance template exists
             pass
         else:
-            # Add the 'scale-set-' prefix to the name
-            name = f'scale-set-{name}'
             instance_template = self.create_instance_template(
                 name,
                 resourceAdapterProfile,
@@ -1643,12 +1633,6 @@ insertnode_request = None
             )
             template_created = True
             instance_template_name = instance_template['name']
-
-        # Get session and connection
-        session = self.get_gce_session(
-            resourceAdapterProfile
-        )
-        connection = session['connection']
 
         # Set up instance group dict
         instanceGroup = {


### PR DESCRIPTION
General description: add ability to create scale sets with a pre-existing instance template rather than always creating a new one for each scale set.

Specifics:
* Update scale set listener to handle new `instance_template_name` parameter in scale set resource requests
* Add validation for scale set creation requests - either a hardware profile and software profile should be provided, or the name of an existing instance template.
* Remove unused parameters from `*_scale_set` methods on resource adapter class and also rewrite anything that called those methods.

I've tested:
* Creating scale sets with specifying a hardware profile and software profile
* Creating scale sets with specifying an existing instance template
* Scale set creation fails when providing an instance template and any combination of a hardware profile and/or a software profile