### PR TITLE
Add custom facter fact for GCP external IP

### DIFF
--- a/tortuga_kits/gceadapter/files/tortuga_gcp_external_ip.sh
+++ b/tortuga_kits/gceadapter/files/tortuga_gcp_external_ip.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+EXT_IP=$(curl -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip 2>/dev/null)
+if [ ! -z "$EXT_IP" ]; then
+    echo "tortuga_gcp_external_ip=$EXT_IP"
+fi

--- a/tortuga_kits/gceadapter/kit.py
+++ b/tortuga_kits/gceadapter/kit.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tortuga.kit.mixins import ResourceAdapterMixin
-from tortuga.kit.installer import KitInstallerBase
+import os
+import shutil
 
+from tortuga.kit.mixins import ResourceAdapterMixin, logger
+from tortuga.kit.installer import KitInstallerBase
 
 class GceInstaller(ResourceAdapterMixin, KitInstallerBase):
     puppet_modules = ['univa-tortuga_kit_gceadapter']
@@ -26,3 +28,21 @@ class GceInstaller(ResourceAdapterMixin, KitInstallerBase):
         'startup_script_bare.py',
     ]
     resource_adapter_name = 'gce'
+
+    # Copy the custom facter fact to the appropriate place
+    src_file = os.path.join(
+        self.files_path,
+        'tortuga_gcp_external_ip.sh'
+    )
+    dst_file = '/opt/puppetlabs/facter/facts.d/tortuga_gcp_external_ip.sh'
+
+    #
+    # Prevent existing file from being overwritten
+    #
+    if os.path.exists(dst_file):
+        dst_file += '.new'
+
+    logger.info(
+        'Writing file: {}'.format(dst_file))
+
+    shutil.copy2(src_file, dst_file)

--- a/tortuga_kits/gceadapter/kit.py
+++ b/tortuga_kits/gceadapter/kit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2008-2018 Univa Corporation
+# Copyright 2008-2020 Univa Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import os
 import shutil
 
-from tortuga.kit.mixins import ResourceAdapterMixin, logger
+from tortuga.kit.mixins import ResourceAdapterMixin
 from tortuga.kit.installer import KitInstallerBase
 
 class GceInstaller(ResourceAdapterMixin, KitInstallerBase):
@@ -29,20 +29,18 @@ class GceInstaller(ResourceAdapterMixin, KitInstallerBase):
     ]
     resource_adapter_name = 'gce'
 
-    # Copy the custom facter fact to the appropriate place
-    src_file = os.path.join(
-        self.files_path,
-        'tortuga_gcp_external_ip.sh'
-    )
-    dst_file = '/opt/puppetlabs/facter/facts.d/tortuga_gcp_external_ip.sh'
+    def  action_post_install(self, *args, **kwargs):
+        # Copy the custom facter fact to the appropriate place
+        src_file = os.path.join(
+            self.files_path,
+            'tortuga_gcp_external_ip.sh'
+        )
+        dst_file = '/opt/puppetlabs/facter/facts.d/tortuga_gcp_external_ip.sh'
 
-    #
-    # Prevent existing file from being overwritten
-    #
-    if os.path.exists(dst_file):
-        dst_file += '.new'
+        #
+        # Prevent existing file from being overwritten
+        #
+        if os.path.exists(dst_file):
+            dst_file += '.new'
 
-    logger.info(
-        'Writing file: {}'.format(dst_file))
-
-    shutil.copy2(src_file, dst_file)
+        shutil.copy2(src_file, dst_file)


### PR DESCRIPTION
The tortuga installed facter application uses the old beta
API which is being deprecated.  This fact provides the critical
info we are presently requiring from GCP metadata.