### PR TITLE
Resolve scale set listener issues

### DIFF
--- a/src/tortuga/resourceAdapter/gceadapter/gce.py
+++ b/src/tortuga/resourceAdapter/gceadapter/gce.py
@@ -1656,6 +1656,7 @@ insertnode_request = None
                 zone=config['zone']
             ).execute()
         except Exception as ex:
+            self._logger.error(f"Error creating scale set: {str(ex)}")
             # Cleanup on failure - if we created an instance template
             # specifically for this scale set, then delete it
             if template_created:


### PR DESCRIPTION
Fixes issue where attempting to delete a scale set that doesn't exist prevents the corresponding resource request from being deleted. We now catch the exception and check whether it corresponds to an 404 error; and if so, continue on.