### PR TITLE
Instance template creation fixes

### DIFF
--- a/src/tortuga/resourceAdapter/gceadapter/gce.py
+++ b/src/tortuga/resourceAdapter/gceadapter/gce.py
@@ -1559,6 +1559,14 @@ insertnode_request = None
                           common_launch_args,
                           persistent_disks=persistent_disks)
 
+        # Process instance data - any accelerators need to specify *only* the
+        # accelerator type string, *not* the full URL. This is a quirk that
+        # only seems to apply to instance templates.
+        for accelerator in instance.get("guestAccelerators", []):
+            type_url = accelerator["acceleratorType"]
+            type_ = type_url.rsplit("/", 1)[-1]
+            accelerator["acceleratorType"] = type_
+
         # Override a few fields to meet instanceTemplates API
         instance["machineType"] = session['config']['type']
         for disk in instance["disks"]:


### PR DESCRIPTION
This PR makes the following fixes to instance template creation:
* If creation fails, only attempt to delete the template if it is *not* a 409 error. This fixes the case where creation fails because an instance template with the same name already exists, but then our failure handling code deletes the template.
* Change the `acceleratorType` in any provided accelerators to be *just* the accelerator name, not a full or partial URL corresponding to the accelerator type. A URL seems to be expected in most cases in the GCP API, like instance creation, but for instance templates, it only wants the short string. See the docs [here](https://googleapis.github.io/google-api-python-client/docs/dyn/compute_v1.instanceTemplates.html#insert) and search for "guestAccelerators" for more information.